### PR TITLE
Fix touch gestures

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/kaosat-dev/most-gestures#README",
   "dependencies": {
-    "most": "^1.7.2"
+    "most": "1.8.0"
   },
   "devDependencies": {
-    "ava": "^0.22.0",
+    "ava": "3.15.0",
     "browser-env": "^3.2.1"
   }
 }

--- a/src/drags.js
+++ b/src/drags.js
@@ -36,6 +36,7 @@ function mouseDrags (mouseDowns$, mouseUps, mouseMoves, settings) {
 function touchDrags (touchStarts$, touchEnds$, touchMoves$, settings) {
   const {pixelRatio} = settings
   return touchStarts$
+    .filter(t => (t.touches.length === 1 || t.touches.length === 3)) // length 2 is pinch (zoom)
     .flatMap(function (e) {
       let startX = e.touches[0].pageX * pixelRatio
       let startY = e.touches[0].pageY * pixelRatio
@@ -68,7 +69,6 @@ function touchDrags (touchStarts$, touchEnds$, touchMoves$, settings) {
 /* drag move interactions press & move(continuously firing)
 */
 function drags ({mouseDowns$, mouseUps$, mouseMoves$, touchStarts$, touchEnds$, longTaps$, touchMoves$}, settings) {
-  touchMoves$ = touchMoves$.filter(t => t.touches.length === 1)
   const drags$ = merge(
     mouseDrags(mouseDowns$, mouseUps$, mouseMoves$, settings),
     touchDrags(touchStarts$, touchEnds$, touchMoves$, settings)


### PR DESCRIPTION
These small changes to the filtering in drags.js allows the propagation of 1 and 3 finger touch gestures.

Also, the versions of most and ava have been bumped to the latest.